### PR TITLE
🌐 (i18n): Restore banner text to English only, keep nav bilingual

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,7 @@
 # Site settings
 # title: 有点豆腐
 # SEOTitle: 有点豆腐|可能是简中世界唯一的vegan播客
-title: 有点豆腐 Slightly Tofu
-title-line1: 有点豆腐
-title-line2: Slightly Tofu
+title: Slightly Tofu
 SEOTitle: 有点豆腐 | Slightly Tofu | A vegan podcast in Chinese
 header-img: img/about-bg-tofu.jpg
 # email: youdiandofu@tmpemail.com

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,7 +21,7 @@
                     </li>
                     {% for page in site.pages %}{% if page.title %}
                     <li>
-                        <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+                        <a href="{{ page.url | prepend: site.baseurl }}">{% if page.nav-title %}{{ page.nav-title }}{% else %}{{ page.title }}{% endif %}</a>
                     </li>
                     {% endif %}{% endfor %}
                 </ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,7 +8,7 @@ layout: default
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1 ">
                 <div class="site-heading">
-                    <h1>{% if page.title %}{{ page.title }}{% elsif site.title-line1 %}{{ site.title-line1 }}<br>{{ site.title-line2 }}{% else %}{{ site.title }}{% endif %}</h1>
+                    <h1>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</h1>
                     <!--<hr class="small">-->
                     <span class="subheading">{{ page.description }}</span>
                 </div>

--- a/about.html
+++ b/about.html
@@ -1,7 +1,8 @@
 ---
 layout: page
-title: "关于 About"
-description: "关于有点豆腐 · About Slightly Tofu"
+title: "About"
+nav-title: "关于 About"
+description: "Hey, this is Slightly Tofu."
 header-img: "img/about-bg-tofu.jpg"
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-description: "一档用中文探讨维根主义的播客 · A vegan podcast in Chinese"
+description: "A vegan podcast in Chinese."
 ---
 
 {% for post in paginator.posts %}

--- a/search.html
+++ b/search.html
@@ -1,7 +1,8 @@
 ---
 layout: page
-title: "搜索 Search"
-description: "搜索有点豆腐的文章 · Search Slightly Tofu"
+title: "Search"
+nav-title: "搜索 Search"
+description: "Search Slightly Tofu"
 
 ---
 

--- a/tags.html
+++ b/tags.html
@@ -1,7 +1,8 @@
 ---
-title: 标签 Tags
+title: Tags
+nav-title: 标签 Tags
 layout: default
-description: 按标签浏览 · Browse by Tags
+description: Browse by Tags
 header-img: "img/about-bg-tofu.jpg"
 ---
 


### PR DESCRIPTION
 ## Summary                                                                           
                                         
  Restore banner/header text to English only while keeping the navigation bar          
  bilingual.                                                                           
                                                                                       
  This addresses the request to have English-only text on the banner (intro-header)
  across all pages, while preserving the bilingual Chinese + English labels in the
  navigation bar.

  ## Changes

  - **Banner text → English only**
    - Site title: `Slightly Tofu` (removed `有点豆腐` prefix and
  `title-line1`/`title-line2`)
    - Homepage description: `"A vegan podcast in Chinese."`
    - About description: `"Hey, this is Slightly Tofu."`
    - Tags description: `"Browse by Tags"`
    - Search description: `"Search Slightly Tofu"`
    - Simplified `<h1>` rendering in `page.html`

  - **Navigation bar → bilingual**
    - Added `nav-title` front matter field, used by `nav.html` when present
    - `首页 Home` / `关于 About` / `标签 Tags` / `搜索 Search`

  ## Files changed

  | File | What changed |
  |------|-------------|
  | `_config.yml` | Reverted `title`, removed `title-line1`/`title-line2` |
  | `_layouts/page.html` | Simplified `<h1>` logic |
  | `_includes/nav.html` | Renders `nav-title` if available, falls back to `title` |
  | `index.html` | English-only description |
  | `about.html` | English title + description, added `nav-title` |
  | `tags.html` | English title + description, added `nav-title` |
  | `search.html` | English title + description, added `nav-title` |