### PR TITLE
🐛 (index): Fix 'By' author label spacing and date format

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ description: "A vegan podcast in Chinese."
         </div>
     </a>
     <p class="post-meta">
-        By {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} on {{ post.date | date: "%B %-d, %Y" }}
+        By {% if post.author %}{{ post.author }}{% else %}{{ site.title }}{% endif %} {{ post.date | date: "%Y年%-m月%-d日" }}
     </p>
 </div>
 <hr>


### PR DESCRIPTION
  Change date format to Chinese on post list
                                                                                       
  Updates the post metadata on the home page:               
  - Date format changed from English (March 15, 2026) to Chinese (2026年3月15日)
  - Removed the on connector between author and date

# Before The Change

<img width="981" height="914" alt="image" src="https://github.com/user-attachments/assets/518f7345-30ba-44fc-a6b0-0265a75eaa5a" />


# After The Change

<img width="965" height="913" alt="image" src="https://github.com/user-attachments/assets/a601a6e1-0d9a-4128-9157-dd141099a090" />
